### PR TITLE
Fix prose: replace "regular open neighbourhood" with subspace regularity wording

### DIFF
--- a/IsarMathLib/Topology_ZF_properties_2.thy
+++ b/IsarMathLib/Topology_ZF_properties_2.thy
@@ -2056,7 +2056,7 @@ happens with locally-$T_2$; can distinguish between spaces other properties cann
 
 subsection\<open>Locally-regular spaces\<close>
 
-text\<open>A topological space is locally-regular if every point has an open neighbourhood
+text\<open>A topological space is locally-regular if every point has a base of neighbourhoods
 whose subspace topology is regular.\<close>
 
 definition

--- a/IsarMathLib/Topology_ZF_properties_2.thy
+++ b/IsarMathLib/Topology_ZF_properties_2.thy
@@ -2056,9 +2056,8 @@ happens with locally-$T_2$; can distinguish between spaces other properties cann
 
 subsection\<open>Locally-regular spaces\<close>
 
-text\<open>A topological space is locally-regular if every point has a neighbourhood basis of
-regular open sets, i.e.\ open sets $U$ satisfying $U = \mathrm{int}(\mathrm{cl}(U))$.
-Equivalently, every point has an open neighbourhood whose subspace topology is regular.\<close>
+text\<open>A topological space is locally-regular if every point has an open neighbourhood
+whose subspace topology is regular.\<close>
 
 definition
   IsLocallyRegular ("_{is locally-regular}" 70)
@@ -2066,7 +2065,7 @@ definition
 
 text\<open>Since regularity is a hereditary property (it passes to every subspace), we can apply
 the general lemma \<open>her_P_is_loc_P\<close>: a space is locally-regular iff every point merely
-has \emph{some} regular open neighbourhood (rather than a full neighbourhood basis of them).\<close>
+has \emph{some} open neighbourhood whose subspace topology is regular (rather than a full neighbourhood basis of them).\<close>
 
 corollary (in topology0) loc_regular:
   shows "(T{is locally-regular}) \<longleftrightarrow> (\<forall>x\<in>\<Union>T. \<exists>A\<in>T. x\<in>A \<and> (T{restricted to}A){is regular})"
@@ -2087,8 +2086,8 @@ proof-
   show ?thesis unfolding IsLocallyRegular_def by auto
 qed
 
-text\<open>Every regular space is locally-regular: the whole space is itself a regular open
-neighbourhood of each of its points.\<close>
+text\<open>Every regular space is locally-regular: the whole space is itself an open
+neighbourhood whose subspace topology is regular, for each of its points.\<close>
 
 lemma (in topology0) regular_imp_locally_regular:
   assumes "T{is regular}"


### PR DESCRIPTION
Fixes review comments on SKolodynski/IsarMathlib#44.

The informal text in the locally-regular section used "regular open neighbourhood" (meaning U = int(cl(U))), but the formal definition `IsLocallyRegular` is based on open neighbourhoods whose **subspace topology is regular** — a different concept.

## Changes

- `text` block at the definition site: removed the "neighbourhood basis of regular open sets, i.e. U = int(cl(U))" sentence; the surviving sentence already states the correct notion.
- `text` block before `loc_regular`: replaced "some regular open neighbourhood" with "some open neighbourhood whose subspace topology is regular".
- `text` block before `regular_imp_locally_regular`: replaced "a regular open neighbourhood" with "an open neighbourhood whose subspace topology is regular".